### PR TITLE
chore: Spectre.Console.Cli 0.55 — Execute en protected

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,8 +14,8 @@
     <!-- DDD -->
     <PackageVersion Include="ValueOf" Version="2.0.31" />
     <!-- Spectre.Console -->
-    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.3" />

--- a/src/tools/Ninjadog.CLI/Commands/AddEntityCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/AddEntityCommand.cs
@@ -5,7 +5,7 @@ namespace Ninjadog.CLI.Commands;
 internal sealed class AddEntityCommand
     : Command<AddEntityCommandSettings>
 {
-    public override int Execute(CommandContext context, AddEntityCommandSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, AddEntityCommandSettings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/tools/Ninjadog.CLI/Commands/BuildCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/BuildCommand.cs
@@ -8,7 +8,7 @@ internal sealed class BuildCommand(
     NinjadogVerbosityOptions verbosityOptions)
     : Command<BuildCommandSettings>
 {
-    public override int Execute(CommandContext context, BuildCommandSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, BuildCommandSettings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/tools/Ninjadog.CLI/Commands/DocsCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/DocsCommand.cs
@@ -9,7 +9,7 @@ internal sealed class DocsCommand : Command<DocsCommandSettings>
 {
     private const string DocsUrl = "https://atypical-consulting.github.io/Ninjadog/";
 
-    public override int Execute(CommandContext context, DocsCommandSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, DocsCommandSettings settings, CancellationToken cancellationToken)
     {
         MarkupLine($"[green]Opening documentation:[/] [blue]{DocsUrl}[/]");
 

--- a/src/tools/Ninjadog.CLI/Commands/EvolveCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/EvolveCommand.cs
@@ -7,7 +7,7 @@ namespace Ninjadog.CLI.Commands;
 internal sealed class EvolveCommand
     : Command<EvolveCommandSettings>
 {
-    public override int Execute(CommandContext context, EvolveCommandSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, EvolveCommandSettings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/tools/Ninjadog.CLI/Commands/InitCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/InitCommand.cs
@@ -34,7 +34,7 @@ internal sealed class InitCommand
         "Custom"
     ];
 
-    public override async Task<int> ExecuteAsync(CommandContext context, InitCommandSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, InitCommandSettings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/tools/Ninjadog.CLI/Commands/UiCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/UiCommand.cs
@@ -30,7 +30,7 @@ internal sealed class UiCommand : AsyncCommand<UiCommandSettings>
     private const int MaxPortRetries = 10;
 
     /// <inheritdoc />
-    public override async Task<int> ExecuteAsync(CommandContext context, UiCommandSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, UiCommandSettings settings, CancellationToken cancellationToken)
     {
         var configPath = Path.Combine(Directory.GetCurrentDirectory(), ConfigFileName);
         var port = FindAvailablePort(settings.Port);

--- a/src/tools/Ninjadog.CLI/Commands/UpdateCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/UpdateCommand.cs
@@ -5,7 +5,7 @@ namespace Ninjadog.CLI.Commands;
 internal sealed class UpdateCommand
     : Command<UpdateCommandSettings>
 {
-    public override int Execute(CommandContext context, UpdateCommandSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, UpdateCommandSettings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/tools/Ninjadog.CLI/Commands/ValidateCommand.cs
+++ b/src/tools/Ninjadog.CLI/Commands/ValidateCommand.cs
@@ -9,7 +9,7 @@ internal sealed class ValidateCommand
     private const int ExitCodeErrors = 1;
     private const int ExitCodeFileNotFound = 2;
 
-    public override int Execute(CommandContext context, ValidateCommandSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, ValidateCommandSettings settings, CancellationToken cancellationToken)
     {
         var filePath = ResolveFilePath(settings.File);
 


### PR DESCRIPTION
Ce dépôt est **encore en Spectre.Console.Cli < 0.55 et compile aujourd'hui**. Le prochain bump Renovate le casserait : en 0.55 `Command.Execute` est devenu `protected`, et un `override` doit conserver l'accessibilité du membre surchargé (CS0507). Le bump et le changement de modificateur doivent donc atterrir **ensemble** — c'est l'objet de cette PR.

**Verdict de l'oracle local avant PR** : `GREEN` -> `GREEN` (1/1 solutions vertes, toutes les `.sln`/`.slnx` du dépôt).

Fichiers :
- `src/tools/Ninjadog.CLI/Commands/AddEntityCommand.cs (1 override(s) -> protected)`
- `src/tools/Ninjadog.CLI/Commands/BuildCommand.cs (1 override(s) -> protected)`
- `src/tools/Ninjadog.CLI/Commands/DocsCommand.cs (1 override(s) -> protected)`
- `src/tools/Ninjadog.CLI/Commands/EvolveCommand.cs (1 override(s) -> protected)`
- `src/tools/Ninjadog.CLI/Commands/InitCommand.cs (1 override(s) -> protected)`
- `src/tools/Ninjadog.CLI/Commands/UiCommand.cs (1 override(s) -> protected)`
- `src/tools/Ninjadog.CLI/Commands/UpdateCommand.cs (1 override(s) -> protected)`
- `src/tools/Ninjadog.CLI/Commands/ValidateCommand.cs (1 override(s) -> protected)`
- `src/Directory.Packages.props (Spectre.Console 0.54.0->0.55.2, Spectre.Console.Cli 0.53.1->0.55.0)`

Généré par `repo-audit/spectre_sweep.py` (règle de famille R1). Merge uniquement si la CI est verte.